### PR TITLE
setuptools is not needed at runtime

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-setuptools>=65.5.1
 colorama


### PR DESCRIPTION
Hi,

I applied this patch today on Debian

https://salsa.debian.org/python-team/packages/domain2idna/-/commit/1b86d4bd0743a7c033a2cac4a54a665701d5b961